### PR TITLE
Feat: Add Notification Badges to Tabs

### DIFF
--- a/game.js
+++ b/game.js
@@ -168,6 +168,7 @@ function initGame() {
     // Welcome notification
     addNotification('Welcome to Airport Clicker! Click "Operate Flight" to start earning money.', 'info');
 }
+    updateTabBadges(); // Initial badge check
 
 // Main click handler
 function handleMainClick() {
@@ -211,6 +212,7 @@ function handleMainClick() {
     renderStaff();
     renderUpgrades();
     
+    updateTabBadges();
     // Debug log
     console.log("After click - Money:", gameState.money, "Passengers:", gameState.passengers);
     
@@ -263,6 +265,7 @@ function gameLoop() {
     // Update passive income rates for display
     gameState.moneyPerSecond = moneyPerSecond;
     gameState.passengersPerSecond = passengersPerSecond;
+    updateTabBadges();
 }
 
 // Check if airport level should increase
@@ -321,6 +324,34 @@ function updateResourceDisplay() {
     document.getElementById('airport-level').textContent = gameState.airportLevel;
 }
 
+// Update tab badges based on affordability and active tab
+function updateTabBadges() {
+    const currentMoney = gameState.money;
+    const activeTabId = document.querySelector('.tab-pane.active')?.id;
+
+    // Check Buildings
+    const canAffordBuilding = gameState.buildings.some(b => b.unlocked && currentMoney >= Math.floor(b.baseCost * Math.pow(1.15, b.owned)));
+    const buildingTabButton = document.querySelector('.tab-button[data-tab="buildings"] .badge');
+    if (buildingTabButton) {
+        buildingTabButton.classList.toggle('visible', canAffordBuilding && activeTabId !== 'buildings');
+    }
+
+    // Check Staff
+    const canAffordStaff = gameState.staff.some(s => s.unlocked && currentMoney >= Math.floor(s.baseCost * Math.pow(1.2, s.owned)));
+    const staffTabButton = document.querySelector('.tab-button[data-tab="staff"] .badge');
+    if (staffTabButton) {
+        staffTabButton.classList.toggle('visible', canAffordStaff && activeTabId !== 'staff');
+    }
+
+    // Check Upgrades
+    const canAffordUpgrade = gameState.upgrades.some(u => u.unlocked && !u.purchased && currentMoney >= u.cost);
+    const upgradeTabButton = document.querySelector('.tab-button[data-tab="upgrades"] .badge');
+    if (upgradeTabButton) {
+        upgradeTabButton.classList.toggle('visible', canAffordUpgrade && activeTabId !== 'upgrades');
+    }
+}
+
+
 // Switch between tabs
 function switchTab(tabId) {
     // Hide all tab panes
@@ -341,6 +372,7 @@ function switchTab(tabId) {
     // Activate selected tab button
     document.querySelector(`.tab-button[data-tab="${tabId}"]`).classList.add('active');
 }
+    updateTabBadges(); // Update badges after tab switch
 
 // Render buildings tab
 function renderBuildings() {
@@ -399,6 +431,7 @@ function buyBuilding(buildingId) {
             // Re-render staff and upgrades to update their buy buttons too
             renderStaff();
             renderUpgrades();
+            updateTabBadges();
         } else {
             console.log(`Cannot afford ${building.name}. Cost: $${cost}, Money: ${gameState.money}`);
         }
@@ -458,6 +491,7 @@ function hireStaff(staffId) {
             
             // Re-render buildings and upgrades to update their buy buttons too
             renderBuildings();
+            updateTabBadges();
             renderUpgrades();
         } else {
             console.log(`Cannot afford ${staff.name}. Cost: $${cost}, Money: ${gameState.money}`);
@@ -486,6 +520,7 @@ function renderUpgrades() {
             
             upgradeList.appendChild(upgradeElement);
             
+            updateTabBadges();
             // Add event listener to buy button
             const buyButton = upgradeElement.querySelector('.buy-button');
             buyButton.addEventListener('click', () => {

--- a/index.html
+++ b/index.html
@@ -34,9 +34,9 @@
                 </div>
 
                 <div class="tabs">
-                    <button class="tab-button active" data-tab="buildings">Buildings</button>
-                    <button class="tab-button" data-tab="staff">Staff</button>
-                    <button class="tab-button" data-tab="upgrades">Upgrades</button>
+                    <button class="tab-button active" data-tab="buildings">Buildings<span class="badge"></span></button>
+                    <button class="tab-button" data-tab="staff">Staff<span class="badge"></span></button>
+                    <button class="tab-button" data-tab="upgrades">Upgrades<span class="badge"></span></button>
                     <button class="tab-button" data-tab="stats">Stats</button>
                 </div>
 

--- a/styles.css
+++ b/styles.css
@@ -278,3 +278,23 @@ footer {
         grid-template-columns: 1fr;
     }
 }
+/* Tab Badges */
+.tab-button {
+    position: relative; /* Needed for absolute positioning of badge */
+}
+
+.badge {
+    display: none; /* Hidden by default */
+    position: absolute;
+    top: 2px;
+    right: 5px;
+    width: 10px;
+    height: 10px;
+    background-color: red;
+    border-radius: 50%;
+    border: 1px solid white;
+}
+
+.badge.visible {
+    display: block; /* Show when visible class is added */
+}


### PR DESCRIPTION
This PR implements notification badges for the Buildings, Staff, and Upgrades tabs.

A red badge will appear on a tab button when:
1. The player can afford at least one item within that tab.
2. The tab is not currently the active tab.

This helps notify the player of available purchases in other tabs without requiring them to constantly switch.