### PR TITLE
Feat(ui): Add level progress bar and unlock info

### DIFF
--- a/game.js
+++ b/game.js
@@ -9,7 +9,8 @@ import {
     updateButtonStates, 
     updateTabBadges, 
     switchTab, 
-    addNotification 
+    addNotification, 
+    renderLevelUnlocks // Added import
 } from './js/modules/ui.js';
 import { handleMainClick, gameLoop } from './js/modules/gameLogic.js';
 
@@ -30,11 +31,14 @@ function initGame() {
     renderStaff();
     renderUpgrades();
     updateButtonStates(); 
+    renderLevelUnlocks();
     updateTabBadges(); 
 
     // Set up event listeners
+    console.log('Setting up event listeners...');
     const mainClicker = document.getElementById('main-clicker');
     if (mainClicker) {
+        console.log('Attaching listener to main-clicker');
         mainClicker.addEventListener('click', handleMainClick);
     } else {
         console.error('Main clicker button not found!');
@@ -42,6 +46,7 @@ function initGame() {
 
     const tabButtons = document.querySelectorAll('.tab-button');
     tabButtons.forEach(button => {
+        console.log(`Attaching listener to tab button for: ${button.getAttribute('data-tab')}`);
         button.addEventListener('click', () => {
             const tabId = button.getAttribute('data-tab');
             if (tabId) {

--- a/index.html
+++ b/index.html
@@ -83,6 +83,9 @@
                                 <span id="airport-level">1</span>
                             </div>
                         </div>
+                        <div id="level-unlocks-list">
+                            <!-- Level unlocks will be added here -->
+                        </div>
                             <div class="stat-action">
                                 <button id="reset-progress-button">Reset Progress</button>
                             </div>

--- a/index.html
+++ b/index.html
@@ -82,13 +82,14 @@
                                 <span>Airport Level: </span>
                                 <span id="airport-level">1</span>
                             </div>
+                            <div class="stat stat-button-container"> <!-- Added container div -->
+                                <button id="reset-progress-button" class="button-reset">Reset Progress</button>
+                            </div>
                         </div>
                         <div id="level-unlocks-list">
                             <!-- Level unlocks will be added here -->
                         </div>
-                            <div class="stat-action">
-                                <button id="reset-progress-button">Reset Progress</button>
-                            </div>
+                        <!-- Removed stat-action div -->
                     </div>
                 </div>
             </div>

--- a/index.html
+++ b/index.html
@@ -23,6 +23,11 @@
                     <span>Reputation: </span>
                     <span id="reputation">0</span>
                 </div>
+                <div class="resource level-progress">
+                    <span>Level Progress: </span>
+                    <progress id="level-progress-bar" value="0" max="10"></progress>
+                    <span id="level-progress-text">0/10 Rep</span>
+                </div>
             </div>
         </header>
 

--- a/js/modules/gameLogic.js
+++ b/js/modules/gameLogic.js
@@ -1,5 +1,5 @@
 // Import state and UI functions
-import { gameState, saveGame, incrementSaveCounter, resetSaveCounter } from './state.js';
+import { gameState, saveGame, saveCounter, incrementSaveCounter, resetSaveCounter } from './state.js';
 import { 
     updateResourceDisplay, 
     showClickFeedback, 
@@ -13,6 +13,7 @@ import {
 
 // Main click handler
 export function handleMainClick() {
+    console.log('handleMainClick called');
     // Prevent rapid clicking
     if (gameState.clickCooldown) return;
     

--- a/js/modules/ui.js
+++ b/js/modules/ui.js
@@ -30,6 +30,27 @@ export function updateResourceDisplay() {
     }
 }
 
+// Define level unlocks (could be moved to definitions.js later)
+const levelUnlocks = {
+    2: ['Control Tower', 'Mechanic'],
+    3: ['Parking Garage'],
+    // Add more levels as needed
+};
+
+// Render level unlock information in the Stats tab
+export function renderLevelUnlocks() {
+    const unlockListEl = document.getElementById('level-unlocks-list');
+    if (!unlockListEl) return;
+
+    let unlockHtml = '<h3>Level Unlocks</h3><ul>';
+    for (const level in levelUnlocks) {
+        unlockHtml += `<li>Level ${level}: ${levelUnlocks[level].join(', ')}</li>`;
+    }
+    unlockHtml += '</ul>';
+
+    unlockListEl.innerHTML = unlockHtml;
+}
+
 // Render buildings tab content
 export function renderBuildings() {
     const buildingList = document.querySelector('.building-list');
@@ -37,30 +58,38 @@ export function renderBuildings() {
     buildingList.innerHTML = '';
 
     gameState.buildings.forEach(building => {
-        if (building.unlocked) {
+        // Removed outer unlocked check - render all, style locked ones
             const buildingCost = Math.floor(building.baseCost * Math.pow(1.15, building.owned));
             const canAfford = gameState.money >= buildingCost;
+            const isLocked = !building.unlocked;
 
             const buildingElement = document.createElement('div');
-            buildingElement.className = 'building-item';
+            buildingElement.className = `building-item ${isLocked ? 'locked' : ''}`;
+            let unlockLevel = '?'; // Determine unlock level (can be improved)
+            if (building.id === 'control-tower') unlockLevel = '2';
+            if (building.id === 'parking-garage') unlockLevel = '3';
+            const lockText = isLocked ? `<span>(Locked - Lvl ${unlockLevel})</span>` : '';
+            const productionText = `Produces: $${building.moneyPerSecond || 0}/s, ${building.passengersPerSecond || 0} passengers/s`;
+
             buildingElement.innerHTML = `
-                <div class="building-name">${building.name} (${building.owned})</div>
+                <div class="building-name">${building.name} (${building.owned})</div> 
                 <div class="building-cost">Cost: $${buildingCost}</div>
                 <div class="building-description">${building.description}</div>
-                <div class="building-production">Produces: $${building.moneyPerSecond}/s, ${building.passengersPerSecond} passengers/s</div>
-                <button class="buy-button" data-building="${building.id}" ${canAfford ? '' : 'disabled'}>Buy</button>
+                <div class="building-production">${productionText}</div>
+                <button class="buy-button" data-building="${building.id}" ${isLocked || !canAfford ? 'disabled' : ''}>${isLocked ? `Locked (Lvl ${unlockLevel})` : 'Buy'}</button>
             `;
 
             buildingList.appendChild(buildingElement);
 
-            // Add event listener to buy button
-            const buyButton = buildingElement.querySelector('.buy-button');
-            if (buyButton) {
-                buyButton.addEventListener('click', () => {
-                    buyBuilding(building.id); // Needs gameLogic.js
-                });
+            // Add event listener only if NOT locked
+            if (!isLocked) {
+                const buyButton = buildingElement.querySelector('.buy-button');
+                if (buyButton) {
+                    buyButton.addEventListener('click', () => {
+                        buyBuilding(building.id); // Needs gameLogic.js
+                    });
+                }
             }
-        }
     });
 }
 
@@ -71,30 +100,37 @@ export function renderStaff() {
     staffList.innerHTML = '';
 
     gameState.staff.forEach(staff => {
-        if (staff.unlocked) {
+        // Removed outer unlocked check
             const staffCost = Math.floor(staff.baseCost * Math.pow(1.2, staff.owned));
             const canAfford = gameState.money >= staffCost;
+            const isLocked = !staff.unlocked;
 
             const staffElement = document.createElement('div');
-            staffElement.className = 'staff-item';
+            staffElement.className = `staff-item ${isLocked ? 'locked' : ''}`;
+            let unlockLevel = '?';
+            if (staff.id === 'mechanic') unlockLevel = '2';
+            const lockText = isLocked ? `<span>(Locked - Lvl ${unlockLevel})</span>` : '';
+            const bonusText = `Click Bonus: ${((staff.clickMultiplier - 1) * 100).toFixed(0)}% per ${staff.name}`; // Using original logic
+
             staffElement.innerHTML = `
                 <div class="staff-name">${staff.name} (${staff.owned})</div>
                 <div class="staff-cost">Cost: $${staffCost}</div>
                 <div class="staff-description">${staff.description}</div>
-                <div class="staff-bonus">Click Bonus: ${((staff.clickMultiplier - 1) * 100).toFixed(0)}% per ${staff.name}</div>
-                <button class="buy-button" data-staff="${staff.id}" ${canAfford ? '' : 'disabled'}>Hire</button>
+                <div class="staff-bonus">${bonusText}</div>
+                <button class="buy-button" data-staff="${staff.id}" ${isLocked || !canAfford ? 'disabled' : ''}>${isLocked ? `Locked (Lvl ${unlockLevel})` : 'Hire'}</button>
             `;
 
             staffList.appendChild(staffElement);
 
-            // Add event listener to buy button
-            const buyButton = staffElement.querySelector('.buy-button');
-            if (buyButton) {
-                buyButton.addEventListener('click', () => {
-                    hireStaff(staff.id); // Needs gameLogic.js
-                });
+            // Add event listener only if NOT locked
+            if (!isLocked) {
+                const buyButton = staffElement.querySelector('.buy-button');
+                if (buyButton) {
+                    buyButton.addEventListener('click', () => {
+                        hireStaff(staff.id); // Needs gameLogic.js
+                    });
+                }
             }
-        }
     });
 }
 
@@ -105,29 +141,31 @@ export function renderUpgrades() {
     upgradeList.innerHTML = ''; // Clear existing items
 
     gameState.upgrades.forEach(upgrade => {
-        // Display the upgrade if it's unlocked
-        if (upgrade.unlocked) {
+        // Removed outer unlocked check
             const canAfford = gameState.money >= upgrade.cost;
             const isPurchased = upgrade.purchased;
+            const isLocked = !upgrade.unlocked;
 
             const upgradeElement = document.createElement('div');
-            // Add 'purchased' class if the upgrade is bought (for CSS styling)
-            upgradeElement.className = `upgrade-item ${isPurchased ? 'purchased' : ''}`;
+            // Add 'purchased' and 'locked' classes
+            upgradeElement.className = `upgrade-item ${isPurchased ? 'purchased' : ''} ${isLocked ? 'locked' : ''}`;
+
+            const lockText = isLocked ? `<span>(Locked)</span>` : ''; // No level info for upgrades yet
 
             upgradeElement.innerHTML = `
                 <div class="upgrade-name">${upgrade.name}</div>
                 <div class="upgrade-cost">Cost: $${upgrade.cost}</div>
                 <div class="upgrade-description">${upgrade.description}</div>
                 <div class="upgrade-effect">${upgrade.effect}</div>
-                <button class="buy-button" data-upgrade="${upgrade.id}" ${isPurchased || !canAfford ? 'disabled' : ''}>
-                    ${isPurchased ? 'Purchased' : 'Purchase'}
+                <button class="buy-button" data-upgrade="${upgrade.id}" ${isLocked || isPurchased || !canAfford ? 'disabled' : ''}>
+                    ${isLocked ? 'Locked' : (isPurchased ? 'Purchased' : 'Purchase')} 
                 </button>
             `;
 
             upgradeList.appendChild(upgradeElement);
 
-            // Add event listener to the buy button ONLY if not purchased
-            if (!isPurchased) {
+            // Add event listener only if NOT locked and NOT purchased
+            if (!isLocked && !isPurchased) {
                 const buyButton = upgradeElement.querySelector('.buy-button');
                 if (buyButton) {
                     buyButton.addEventListener('click', () => {
@@ -135,7 +173,6 @@ export function renderUpgrades() {
                     });
                 }
             }
-        }
     });
 }
 
@@ -147,7 +184,8 @@ export function updateButtonStates() {
     buttons.forEach(button => {
         let item;
         let cost;
-        let isPurchased = false; // Specific to upgrades
+        let isLocked = false; 
+        let isPurchased = false; // Declare isPurchased here
 
         const buildingId = button.getAttribute('data-building');
         const staffId = button.getAttribute('data-staff');
@@ -157,23 +195,26 @@ export function updateButtonStates() {
             item = gameState.buildings.find(b => b.id === buildingId);
             if (item) {
                 cost = Math.floor(item.baseCost * Math.pow(1.15, item.owned));
+                isLocked = !item.unlocked;
             }
         } else if (staffId) {
             item = gameState.staff.find(s => s.id === staffId);
             if (item) {
                 cost = Math.floor(item.baseCost * Math.pow(1.2, item.owned));
+                isLocked = !item.unlocked;
             }
         } else if (upgradeId) {
             item = gameState.upgrades.find(u => u.id === upgradeId);
             if (item) {
                 cost = item.cost;
                 isPurchased = item.purchased;
+                isLocked = !item.unlocked;
             }
         }
 
         if (item) {
-            // Disable if purchased (for upgrades) or if cannot afford
-            button.disabled = isPurchased || currentMoney < cost;
+            // Disable if locked, purchased (for upgrades), or if cannot afford
+            button.disabled = isLocked || isPurchased || currentMoney < cost;
         } else {
             // If item not found for some reason, disable the button
             button.disabled = true;
@@ -210,6 +251,7 @@ export function updateTabBadges() {
 
 // Switch between tabs in the UI
 export function switchTab(tabId) {
+    console.log(`switchTab called with tabId: ${tabId}`);
     // Hide all tab panes
     const tabPanes = document.querySelectorAll('.tab-pane');
     tabPanes.forEach(pane => {

--- a/js/modules/ui.js
+++ b/js/modules/ui.js
@@ -39,16 +39,34 @@ const levelUnlocks = {
 
 // Render level unlock information in the Stats tab
 export function renderLevelUnlocks() {
+    console.log("Attempting to render level unlocks...");
     const unlockListEl = document.getElementById('level-unlocks-list');
-    if (!unlockListEl) return;
+    if (!unlockListEl) {
+        console.error("#level-unlocks-list element not found!");
+        return;
+    }
 
     let unlockHtml = '<h3>Level Unlocks</h3><ul>';
-    for (const level in levelUnlocks) {
-        unlockHtml += `<li>Level ${level}: ${levelUnlocks[level].join(', ')}</li>`;
+    console.log("Initial unlockHtml:", unlockHtml);
+    try {
+        for (const level in levelUnlocks) {
+            console.log(`Processing level: ${level}`);
+            const unlocks = levelUnlocks[level];
+            if (Array.isArray(unlocks)) {
+                const joinedUnlocks = unlocks.join(', ');
+                console.log(`  Unlocks for level ${level}: ${joinedUnlocks}`);
+                unlockHtml += `<li>Level ${level}: ${joinedUnlocks}</li>`;
+            } else {
+                console.warn(`  Data for level ${level} is not an array:`, unlocks);
+            }
+        }
+        unlockHtml += '</ul>';
+        console.log("Final unlockHtml:", unlockHtml);
+        unlockListEl.innerHTML = unlockHtml;
+    } catch (error) {
+        console.error("Error during unlock list generation:", error);
+        unlockListEl.innerHTML = '<h3>Error loading unlocks</h3>'; // Show error in UI
     }
-    unlockHtml += '</ul>';
-
-    unlockListEl.innerHTML = unlockHtml;
 }
 
 // Render buildings tab content

--- a/js/modules/ui.js
+++ b/js/modules/ui.js
@@ -10,6 +10,8 @@ export function updateResourceDisplay() {
     const totalFlightsEl = document.getElementById('total-flights');
     const totalPassengersEl = document.getElementById('total-passengers');
     const airportLevelEl = document.getElementById('airport-level');
+    const levelProgressBar = document.getElementById('level-progress-bar');
+    const levelProgressText = document.getElementById('level-progress-text');
 
     if (moneyEl) moneyEl.textContent = gameState.money.toFixed(1);
     if (passengersEl) passengersEl.textContent = gameState.passengers.toFixed(0);
@@ -17,6 +19,15 @@ export function updateResourceDisplay() {
     if (totalFlightsEl) totalFlightsEl.textContent = gameState.totalFlights;
     if (totalPassengersEl) totalPassengersEl.textContent = gameState.totalPassengers.toFixed(0);
     if (airportLevelEl) airportLevelEl.textContent = gameState.airportLevel;
+
+    // Update Level Progress Bar
+    if (levelProgressBar && levelProgressText) {
+        const currentLevelRep = gameState.reputation % 10;
+        const repNeeded = 10;
+        levelProgressBar.value = currentLevelRep;
+        levelProgressBar.max = repNeeded;
+        levelProgressText.textContent = `${currentLevelRep}/${repNeeded} Rep`;
+    }
 }
 
 // Render buildings tab content

--- a/styles.css
+++ b/styles.css
@@ -345,3 +345,90 @@ footer {
     color: #666;
     margin-left: 5px;
 }
+
+/* Level Unlocks List Styling */
+#level-unlocks-list {
+    margin-top: 20px; /* Add space above the list */
+    padding: 10px;
+    background-color: #f8f9fa; /* Match stat item background */
+    border: 1px solid #ddd;    /* Match stat item border */
+    border-radius: 5px;
+}
+
+#level-unlocks-list h3 {
+    margin-bottom: 10px;
+    padding-bottom: 5px;
+    border-bottom: 1px solid #eee; /* Lighter border for heading */
+    font-size: 1.1em;
+}
+
+#level-unlocks-list ul {
+    list-style: disc; /* Use standard bullets */
+    padding-left: 25px; /* Indent list items */
+}
+
+#level-unlocks-list li {
+    margin-bottom: 5px; /* Space out list items */
+}
+
+/* Refined Locked Item Styling */
+.building-item.locked,
+.staff-item.locked,
+.upgrade-item.locked {
+    opacity: 0.65; /* Slightly less transparent */
+    background-color: #f0f0f0; /* Add a light grey background */
+    border-left: 3px solid #aaa; /* Darker grey border */
+}
+
+/* Keep lock text relatively small and grey */
+.building-item.locked .building-name span,
+.staff-item.locked .staff-name span,
+.upgrade-item.locked .upgrade-name span {
+    font-size: 0.8em;
+    font-weight: normal; /* Don't bold the lock text */
+    color: #555;
+    margin-left: 8px;
+}
+
+/* Stats Tab Button Styling */
+.stats-container {
+    /* Ensure it remains a grid */
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 15px;
+    align-items: center; /* Vertically align items in the grid */
+}
+
+.stat-button-container {
+    /* Override default stat padding/border if needed, or just align */
+    padding: 0; 
+    border: none;
+    background-color: transparent;
+    display: flex; /* Use flexbox for alignment within the cell */
+    justify-content: flex-start; /* Align button to the start */
+    align-items: center; /* Center button vertically */
+}
+
+.button-reset {
+    /* Base styles similar to .buy-button */
+    color: white;
+    border: none;
+    padding: 5px 10px;
+    border-radius: 3px;
+    cursor: pointer;
+    transition: background-color 0.2s, transform 0.1s;
+    font-size: 0.9em; /* Slightly smaller than buy buttons maybe */
+    
+    /* Specific reset button color (e.g., warning/danger) */
+    background-color: #e74c3c; /* Red */
+    width: auto; /* Allow button to size to content */
+}
+
+.button-reset:hover {
+    background-color: #c0392b; /* Darker red */
+    transform: translateY(-2px);
+}
+
+.button-reset:active {
+    transform: translateY(0);
+}

--- a/styles.css
+++ b/styles.css
@@ -1,80 +1,3 @@
-# Read the file content
-current_content_response = default_api.read_file(path="game.js")
-if current_content_response['read_file_response']['status'] != 'succeeded':
-    print("Error reading game.js again.")
-else:
-    current_content = current_content_response['read_file_response']['result']
-    
-    # Define the unique start and end markers of the Python block
-    # Using markers that are less likely to appear elsewhere
-    python_start_marker = "# Read the current content of game.js\\ngame_js_content = default_api.read_file"
-    python_end_marker = "print(\\\"Error: Could not find the upgradeDefinitions array in game.js\\\")" # The last line of the python code
-
-    start_index = current_content.find(python_start_marker)
-    end_index = current_content.find(python_end_marker)
-
-    if start_index != -1 and end_index != -1 and end_index > start_index:
-        # Find the beginning of the line where the start marker is (actually the line before it)
-        # Look for the end of the previous correct JS line
-        js_line_before_start = "totalPassengers: 0,"
-        start_js_index = current_content.find(js_line_before_start)
-        
-        if start_js_index != -1:
-             line_start_index = start_js_index + len(js_line_before_start)
-             # Ensure we capture the newline right after the JS line to start the removal
-             if current_content[line_start_index] == '\\n':
-                  line_start_index += 1
-             elif current_content[line_start_index:line_start_index+2] == '\\r\\n': # Handle Windows line endings
-                  line_start_index += 2
-        else:
-             # Fallback if the exact JS line isn't found (shouldn't happen here)
-             line_start_index = current_content.rfind('\\n', 0, start_index)
-             if line_start_index == -1:
-                 line_start_index = 0
-             else:
-                 line_start_index += 1
-        
-
-        # Find the end of the line where the end marker is
-        line_end_index = current_content.find('\\n', end_index)
-        if line_end_index == -1:
-             line_end_index = len(current_content) # Marker might be on the last line
-        else:
-             # Check if the next line is the correct JS line
-             js_line_after_end = "    airportLevel: 1,"
-             next_line_start = line_end_index + 1
-             if current_content.startswith(js_line_after_end, next_line_start):
-                 line_end_index = next_line_start # Set end index to start of the next correct line
-             else:
-                 # If the next line isn't what we expect, just remove up to the end marker's line end
-                 line_end_index += 1
-
-
-        # Construct the corrected code
-        part1 = current_content[:line_start_index] # Code before the bad block lines
-        part2 = current_content[line_end_index:]   # Code after the bad block lines
-
-        # Ensure part1 ends with a newline if it doesn't already, and part2 doesn't start with one redundantly
-        if not part1.endswith('\\n') and not part1.endswith('\\r'):
-             part1 += '\\n' # Add a newline if missing
-        
-        # Remove leading whitespace/newlines from part2 if part1 added a newline
-        part2 = part2.lstrip('\\n\\r')
-
-
-        corrected_content = part1 + part2 
-        
-        # Final verification
-        if "renderUpgrades()" in corrected_content and "upgradeDefinitions = [" in corrected_content and "airportLevel: 1," in corrected_content and python_start_marker not in corrected_content:
-             print("Attempting to write corrected game.js...")
-             print(default_api.write_file(content=corrected_content, path="game.js"))
-        else:
-              print("Error: Corrected content seems invalid after removal attempt or markers still present. Aborting write.")
-              #print(f"Debug Info: Part 1 ends with: {repr(part1[-20:])}") # Keep it concise
-              #print(f"Debug Info: Part 2 starts with: {repr(part2[:20])}")
-
-    else:
-        print(f"Error: Could not locate the Python code markers in game.js. Start index: {start_index}, End index: {end_index}")
 * {
     box-sizing: border-box;
     margin: 0;
@@ -406,3 +329,19 @@ footer {
     transform: none;
 }
 /* ---- End purchased upgrade styles ---- */
+
+/* Locked item styling */
+.building-item.locked,
+.staff-item.locked,
+.upgrade-item.locked {
+    opacity: 0.6;
+    border-left: 3px solid #ccc; /* Add a visual cue */
+}
+
+.building-item.locked .building-name span,
+.staff-item.locked .staff-name span,
+.upgrade-item.locked .upgrade-name span {
+    font-size: 0.8em;
+    color: #666;
+    margin-left: 5px;
+}


### PR DESCRIPTION
This PR implements the feature request from Issue #6.

- Adds a progress bar to the header showing reputation progress towards the next level.
- Adds a list of level unlocks to the Stats tab.
- Adds styling to visually indicate locked items in the Buildings, Staff, and Upgrades tabs.
- Fixes related bugs in button state updates.
- Improves styling of the unlock list and the Reset Progress button.

Closes #6.